### PR TITLE
feat: declare public API contracts

### DIFF
--- a/Block/System/Config/Logger/LogeLevels.php
+++ b/Block/System/Config/Logger/LogeLevels.php
@@ -16,6 +16,10 @@ namespace HawkSearch\Connector\Block\System\Config\Logger;
 
 use Monolog\Logger;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class LogeLevels  implements \Magento\Framework\Option\ArrayInterface
 {
     /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### API CHANGES
+#### Interfaces
+The following interfaces in `\HawkSearch\Connector` namespace are defined as `@api`:
+- Gateway\Config\ApiConfigInterface
+- Gateway\Http\ConverterInterface
+- Gateway\Http\Uri\UriBuilderInterface
+- Gateway\Http\Instruction\InstructionManagerInterface
+- Gateway\Http\Instruction\InstructionManagerPoolInterface
+
+#### Classes
+The following classes in `\HawkSearch\Connector` namespace are defined as `@api`:
+- Block\System\Config\Logger\LogeLevels
+- Gateway\Helper\HttpResponseReader
+- Gateway\Helper\SubjectReader
+- Gateway\Http\JsonToArray
+- Gateway\Http\Instruction\InstructionManager
+- Gateway\Http\Instruction\InstructionManagerPool
+- Gateway\Instruction\Result\ArrayResult
+- Gateway\Instruction\Result\DefaultResult
+- Gateway\Request\BuilderComposite
+- Gateway\Request\StrictDataBuilder
+- Gateway\Response\HandlerChain
+- Gateway\Validator\ValidatorComposite
+- Helper\Url
+
+
+
 ## [2.10.0] - 2024-07-02
 ## FEATURES
 * feat: add deprecation message utility classes  ([#22](https://github.com/hawksearch/connector-magento-2/pull/22), [#23](https://github.com/hawksearch/connector-magento-2/pull/23))

--- a/Gateway/Config/ApiConfigInterface.php
+++ b/Gateway/Config/ApiConfigInterface.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Config;
 
+/**
+ * @api
+ * @since 2.11
+ */
 interface ApiConfigInterface
 {
     /**

--- a/Gateway/Helper/HttpResponseReader.php
+++ b/Gateway/Helper/HttpResponseReader.php
@@ -17,6 +17,10 @@ namespace HawkSearch\Connector\Gateway\Helper;
 
 use HawkSearch\Connector\Gateway\Http\ClientInterface;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class HttpResponseReader
 {
     /**

--- a/Gateway/Helper/SubjectReader.php
+++ b/Gateway/Helper/SubjectReader.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Helper;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class SubjectReader
 {
     /**

--- a/Gateway/Http/Converter/JsonToArray.php
+++ b/Gateway/Http/Converter/JsonToArray.php
@@ -18,6 +18,8 @@ use Magento\Framework\Serialize\Serializer\Json;
 
 /**
  * Class JsonToArray
+ * @api
+ * @since 2.11
  */
 class JsonToArray implements ConverterInterface
 {

--- a/Gateway/Http/ConverterInterface.php
+++ b/Gateway/Http/ConverterInterface.php
@@ -14,6 +14,8 @@ namespace HawkSearch\Connector\Gateway\Http;
 
 /**
  * Interface ConverterInterface
+ * @api
+ * @since 2.11
  */
 interface ConverterInterface
 {

--- a/Gateway/Http/Uri/UriBuilderInterface.php
+++ b/Gateway/Http/Uri/UriBuilderInterface.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Http\Uri;
 
+/**
+ * @api
+ * @since 2.11
+ */
 interface UriBuilderInterface
 {
     /**

--- a/Gateway/Instruction/InstructionManager.php
+++ b/Gateway/Instruction/InstructionManager.php
@@ -18,6 +18,10 @@ use HawkSearch\Connector\Gateway\InstructionInterface;
 use HawkSearch\Connector\Gateway\InstructionException;
 use Magento\Framework\Exception\NotFoundException;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class InstructionManager implements InstructionManagerInterface
 {
     /**

--- a/Gateway/Instruction/InstructionManagerInterface.php
+++ b/Gateway/Instruction/InstructionManagerInterface.php
@@ -18,6 +18,10 @@ use HawkSearch\Connector\Gateway\InstructionException;
 use HawkSearch\Connector\Gateway\InstructionInterface;
 use Magento\Framework\Exception\NotFoundException;
 
+/**
+ * @api
+ * @since 2.11
+ */
 interface InstructionManagerInterface
 {
     /**

--- a/Gateway/Instruction/InstructionManagerPool.php
+++ b/Gateway/Instruction/InstructionManagerPool.php
@@ -18,6 +18,10 @@ use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\ObjectManager\TMap;
 use Magento\Framework\ObjectManager\TMapFactory;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class InstructionManagerPool implements InstructionManagerPoolInterface
 {
     /**

--- a/Gateway/Instruction/InstructionManagerPoolInterface.php
+++ b/Gateway/Instruction/InstructionManagerPoolInterface.php
@@ -16,6 +16,10 @@ namespace HawkSearch\Connector\Gateway\Instruction;
 
 use Magento\Framework\Exception\NotFoundException;
 
+/**
+ * @api
+ * @since 2.11
+ */
 interface InstructionManagerPoolInterface
 {
     /**

--- a/Gateway/Instruction/Result/ArrayResult.php
+++ b/Gateway/Instruction/Result/ArrayResult.php
@@ -17,6 +17,10 @@ namespace HawkSearch\Connector\Gateway\Instruction\Result;
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class ArrayResult implements ResultInterface
 {
     /**

--- a/Gateway/Instruction/Result/DefaultResult.php
+++ b/Gateway/Instruction/Result/DefaultResult.php
@@ -16,6 +16,10 @@ namespace HawkSearch\Connector\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class DefaultResult implements ResultInterface
 {
     /**

--- a/Gateway/Request/BuilderComposite.php
+++ b/Gateway/Request/BuilderComposite.php
@@ -17,6 +17,10 @@ namespace HawkSearch\Connector\Gateway\Request;
 use Magento\Framework\ObjectManager\TMap;
 use Magento\Framework\ObjectManager\TMapFactory;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class BuilderComposite implements BuilderInterface
 {
     /**

--- a/Gateway/Request/StrictDataBuilder.php
+++ b/Gateway/Request/StrictDataBuilder.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Request;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class StrictDataBuilder implements BuilderInterface
 {
     /**

--- a/Gateway/Response/HandlerChain.php
+++ b/Gateway/Response/HandlerChain.php
@@ -17,6 +17,10 @@ namespace HawkSearch\Connector\Gateway\Response;
 use Magento\Framework\ObjectManager\TMap;
 use Magento\Framework\ObjectManager\TMapFactory;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class HandlerChain implements HandlerInterface
 {
     /**

--- a/Gateway/Validator/ValidatorComposite.php
+++ b/Gateway/Validator/ValidatorComposite.php
@@ -18,6 +18,8 @@ use HawkSearch\Connector\Gateway\Validator\ResultInterfaceFactory;
 
 /**
  * Compiles a result using the results of multiple validators
+ * @api
+ * @since
  */
 class ValidatorComposite extends AbstractValidator
 {

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -18,6 +18,10 @@ namespace HawkSearch\Connector\Helper;
 use GuzzleHttp\Psr7\UriFactory;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @api
+ * @since 2.11
+ */
 class Url
 {
     /**

--- a/Logger/LoggerConfigInterface.php
+++ b/Logger/LoggerConfigInterface.php
@@ -16,6 +16,10 @@ namespace HawkSearch\Connector\Logger;
 
 use Monolog\Logger;
 
+/**
+ * @api
+ * @since 2.11
+ */
 interface LoggerConfigInterface
 {
     const DEFAULT_LOG_LEVEL = Logger::DEBUG;

--- a/Logger/LoggerFactory.php
+++ b/Logger/LoggerFactory.php
@@ -21,9 +21,9 @@ use Monolog\Logger as MonologLogger;
 use Psr\Log\NullLogger;
 
 /**
- * Factory produces logger based on runtime configuration.
- *
- * phpcs:disable MEQP2.Classes.ObjectManager
+ * Factory produces logger based on configuration.
+ * @api
+ * @since 2.11
  */
 class LoggerFactory implements LoggerFactoryInterface
 {

--- a/Logger/LoggerFactoryInterface.php
+++ b/Logger/LoggerFactoryInterface.php
@@ -16,6 +16,10 @@ namespace HawkSearch\Connector\Logger;
 
 use Psr\Log\LoggerInterface;
 
+/**
+ * @api
+ * @since 2.11
+ */
 interface LoggerFactoryInterface
 {
     /**

--- a/Model/ConfigProviderInterface.php
+++ b/Model/ConfigProviderInterface.php
@@ -18,6 +18,10 @@ namespace HawkSearch\Connector\Model;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Model\ScopeInterface;
 
+/**
+ * @api
+ * @since 2.11
+ */
 interface ConfigProviderInterface
 {
     /**


### PR DESCRIPTION
The goal is to define the API layer. Define classes and interfaces related to public API using `@api` phpDoc annotation. Mention this in the document [Backward compatibility policy](https://developerdocs.hawksearch.com/docs/magento-developers-bc-policy)
We will be using this as a basis for Breaking Compatibility changes