### PR TITLE
fix(Compatibility): support classes derived from DataObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### FIXES
+* fix(Compatibility): support classes derived from DataObject ([#34](https://github.com/hawksearch/connector-magento-2/pull/34)
+
 ### API CHANGES
 #### Interfaces
 The following interfaces in `\HawkSearch\Connector` namespace are defined as `@api`:
@@ -35,10 +38,10 @@ The following classes in `\HawkSearch\Connector` namespace are defined as `@api`
 
 
 ## [2.10.0] - 2024-07-02
-## FEATURES
+### FEATURES
 * feat: add deprecation message utility classes  ([#22](https://github.com/hawksearch/connector-magento-2/pull/22), [#23](https://github.com/hawksearch/connector-magento-2/pull/23))
 
-## FIXES
+### FIXES
 * fix: debug message display order in Http/Client class ([072198d](https://github.com/hawksearch/connector-magento-2/pull/27/commits/072198db7a2cf73560427429e5093b56627c7bf8))
 
 ## [2.9.0] - 2024-05-28

--- a/Test/Unit/Compatibility/Fixtures/PublicMethodDeprecationFixture.php
+++ b/Test/Unit/Compatibility/Fixtures/PublicMethodDeprecationFixture.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace HawkSearch\Connector\Test\Unit\Compatibility\Fixtures;
 
 use HawkSearch\Connector\Compatibility\PublicMethodDeprecationTrait;
+use Magento\Framework\DataObject;
 
 class PublicMethodDeprecationBase
 {
@@ -109,5 +110,72 @@ class PublicMethodDeprecationDerived extends PublicMethodDeprecationBase
     public function doOverwrittenDeprecatedAction(string $arg): string
     {
         return parent::doOverwrittenDeprecatedAction($arg) . ' in derived class';
+    }
+}
+
+class DeprecatedFromDataObject extends DataObject
+{
+    use PublicMethodDeprecationTrait;
+
+    private string $something = 'Initial Something';
+    private array $deprecatedMethods = [];
+
+    public function __construct(array $deprecatedMethods)
+    {
+        $this->deprecatedMethods = $deprecatedMethods;
+    }
+
+    public function setSomething(string $value): self
+    {
+        $this->something = $value . ' set';
+        return $this;
+    }
+
+    public function getSomething(): string
+    {
+        return $this->something . ' get';
+    }
+
+    public function hasSomething(): bool
+    {
+        return isset($this->something);
+    }
+
+    public function unsSomething(): self
+    {
+        unset($this->something);
+        return $this;
+    }
+
+    public function doSomethingUsual(): string
+    {
+        return $this->something;
+    }
+
+    private function setSomethingPrivate($value)
+    {
+        $this->something = $value . ' set';
+        return $this;
+    }
+
+    private function getSomethingPrivate()
+    {
+        return $this->something . ' get';
+    }
+
+    private function hasSomethingPrivate()
+    {
+        return isset($this->something);
+    }
+
+    private function unsSomethingPrivate()
+    {
+        unset($this->something);
+        return $this;
+    }
+
+    private function doSomethingUsualPrivate(): string
+    {
+        return $this->something;
     }
 }

--- a/Test/Unit/Compatibility/LegacyBaseTrait.php
+++ b/Test/Unit/Compatibility/LegacyBaseTrait.php
@@ -32,7 +32,7 @@ trait LegacyBaseTrait
     private int $errorReporting;
 
     /**
-     * Use it in {@see TestCase::setUp()}
+     * Use it in testing legacy functionality in very beginingn of a test method.
      */
     private function setUpLegacy(TestCase $testCase): void
     {
@@ -68,7 +68,7 @@ trait LegacyBaseTrait
     }
 
     /**
-     * Use it in {@see TestCase::tearDown()}
+     * Use it in testing legacy functionality in very end of a test method.
      */
     private function tearDownLegacy(TestCase $testCase): void
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,14 @@ parameters:
         - Logger
         - Model
         - Setup
-#    ignoreErrors:
+        - Test
+    ignoreErrors:
+        -
+            # Private properties defined in class and used in traits of \HawkSearch\Connector\Compatibility
+            message: '#Property [a-zA-Z0-9\\_]+::\$(deprecatedMethods|deprecatedPublicProperties) is never read, only written.#'
+        -
+            # Private properties defined in class and used in traits of \HawkSearch\Connector\Compatibility
+            message: '#Property [a-zA-Z0-9\\_]+::\$(deprecatedMethods|deprecatedPublicProperties) type has no value type specified in iterable type array.#'
 #        -
 #            identifier: missingType.parameter
 #            paths:


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 2.11 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | Fix/Ref HC-1703

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained stable branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too). Lowest stable is `master` now.
 - Features and deprecations must be submitted against the latest branch. Latest is a branch for active development.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow (doc link will be added later)
 - Never break backward compatibility (see https://developerdocs.hawksearch.com/docs/magento-developers-bc-policy).
-->

When PublicMethodDeprecationTrait was used in classes derived from DataObject then the were a conflict in the magic method __call. This PR fixes the magic method logic and passes execution to `parent::__call` when it is needed