### PR TITLE
feat: add return types on internal/final/private methods and annotations on public

### DIFF
--- a/Api/Data/HawkSearchFieldInterface.php
+++ b/Api/Data/HawkSearchFieldInterface.php
@@ -308,6 +308,9 @@ interface HawkSearchFieldInterface
      */
     public function setTags(string $value);
 
+    /**
+     * @return int[]
+     */
     public function getIterations(): array;
 
     /**

--- a/Api/Data/HawkSearchFieldInterface.php
+++ b/Api/Data/HawkSearchFieldInterface.php
@@ -63,9 +63,6 @@ interface HawkSearchFieldInterface
     const CREATE_DATE = 'CreateDate';
     const MODIFY_DATE = 'ModifyDate';
 
-    /**
-     * @return int
-     */
     public function getFieldId(): int;
 
     /**
@@ -73,9 +70,6 @@ interface HawkSearchFieldInterface
      */
     public function setFieldId(string $value);
 
-    /**
-     * @return string
-     */
     public function getSyncGuid(): string;
 
     /**
@@ -83,9 +77,6 @@ interface HawkSearchFieldInterface
      */
     public function setSyncGuid(string $value);
 
-    /**
-     * @return string
-     */
     public function getName(): string;
 
     /**
@@ -93,9 +84,6 @@ interface HawkSearchFieldInterface
      */
     public function setName(string $value);
 
-    /**
-     * @return string
-     */
     public function getFieldType(): string;
 
     /**
@@ -103,9 +91,6 @@ interface HawkSearchFieldInterface
      */
     public function setFieldType(string $value);
 
-    /**
-     * @return string
-     */
     public function getLabel(): string;
 
     /**
@@ -113,9 +98,6 @@ interface HawkSearchFieldInterface
      */
     public function setLabel(string $value);
 
-    /**
-     * @return string
-     */
     public function getType(): string;
 
     /**
@@ -123,9 +105,6 @@ interface HawkSearchFieldInterface
      */
     public function setType(string $value);
 
-    /**
-     * @return int
-     */
     public function getBoost(): int;
 
     /**
@@ -133,9 +112,6 @@ interface HawkSearchFieldInterface
      */
     public function setBoost(int $value);
 
-    /**
-     * @return int
-     */
     public function getFacetHandler(): int;
 
     /**
@@ -143,9 +119,6 @@ interface HawkSearchFieldInterface
      */
     public function setFacetHandler(int $value);
 
-    /**
-     * @return bool
-     */
     public function getIsPrimaryKey(): bool;
 
     /**
@@ -153,9 +126,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsPrimaryKey(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsOutput(): bool;
 
     /**
@@ -163,9 +133,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsOutput(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsShingle(): bool;
 
     /**
@@ -173,9 +140,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsShingle(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsBestFragment(): bool;
 
     /**
@@ -183,9 +147,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsBestFragment(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsDictionary(): bool;
 
     /**
@@ -193,9 +154,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsDictionary(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsSort(): bool;
 
     /**
@@ -203,9 +161,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsSort(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsPrefix(): bool;
 
     /**
@@ -213,9 +168,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsPrefix(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsHidden(): bool;
 
     /**
@@ -223,9 +175,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsHidden(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsCompare(): bool;
 
     /**
@@ -233,9 +182,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsCompare(bool $value);
 
-    /**
-     * @return int
-     */
     public function getSortOrder(): int;
 
     /**
@@ -243,9 +189,6 @@ interface HawkSearchFieldInterface
      */
     public function setSortOrder(int $value);
 
-    /**
-     * @return string
-     */
     public function getPartialQuery(): string;
 
     /**
@@ -253,9 +196,6 @@ interface HawkSearchFieldInterface
      */
     public function setPartialQuery(string $value);
 
-    /**
-     * @return bool
-     */
     public function getIsKeywordText(): bool;
 
     /**
@@ -263,9 +203,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsKeywordText(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsQuery(): bool;
 
     /**
@@ -273,9 +210,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsQuery(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getIsQueryText(): bool;
 
     /**
@@ -283,9 +217,6 @@ interface HawkSearchFieldInterface
      */
     public function setIsQueryText(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getSkipCustom(): bool;
 
     /**
@@ -293,9 +224,6 @@ interface HawkSearchFieldInterface
      */
     public function setSkipCustom(bool $value);
 
-    /**
-     * @return bool
-     */
     public function getStripHtml(): bool;
 
     /**
@@ -303,9 +231,6 @@ interface HawkSearchFieldInterface
      */
     public function setStripHtml(bool $value);
 
-    /**
-     * @return int
-     */
     public function getMinNGramAnalyzer(): int;
 
     /**
@@ -313,9 +238,6 @@ interface HawkSearchFieldInterface
      */
     public function setMinNGramAnalyzer(int $value);
 
-    /**
-     * @return int
-     */
     public function getMaxNGramAnalyzer(): int;
 
     /**
@@ -323,9 +245,6 @@ interface HawkSearchFieldInterface
      */
     public function setMaxNGramAnalyzer(int $value);
 
-    /**
-     * @return int
-     */
     public function getCoordinateType(): int;
 
     /**
@@ -333,9 +252,6 @@ interface HawkSearchFieldInterface
      */
     public function setCoordinateType(int $value);
 
-    /**
-     * @return bool
-     */
     public function getOmitNorms(): bool;
 
     /**
@@ -343,9 +259,6 @@ interface HawkSearchFieldInterface
      */
     public function setOmitNorms(bool $value);
 
-    /**
-     * @return string
-     */
     public function getItemMapping(): string;
 
     /**
@@ -353,9 +266,6 @@ interface HawkSearchFieldInterface
      */
     public function setItemMapping(string $value);
 
-    /**
-     * @return string
-     */
     public function getDefaultValue(): string;
 
     /**
@@ -363,9 +273,6 @@ interface HawkSearchFieldInterface
      */
     public function setDefaultValue(string $value);
 
-    /**
-     * @return bool
-     */
     public function getUseForPrediction(): bool;
 
     /**
@@ -373,9 +280,6 @@ interface HawkSearchFieldInterface
      */
     public function setUseForPrediction(bool $value);
 
-    /**
-     * @return string
-     */
     public function getCopyTo(): string;
 
     /**
@@ -383,9 +287,6 @@ interface HawkSearchFieldInterface
      */
     public function setCopyTo(string $value);
 
-    /**
-     * @return string
-     */
     public function getAnalyzer(): string;
 
     /**
@@ -393,9 +294,6 @@ interface HawkSearchFieldInterface
      */
     public function setAnalyzer(string $value);
 
-    /**
-     * @return bool
-     */
     public function getDoNotStore(): bool;
 
     /**
@@ -403,9 +301,6 @@ interface HawkSearchFieldInterface
      */
     public function setDoNotStore(bool $value);
 
-    /**
-     * @return string
-     */
     public function getTags(): string;
 
     /**
@@ -413,9 +308,6 @@ interface HawkSearchFieldInterface
      */
     public function setTags(string $value);
 
-    /**
-     * @return array
-     */
     public function getIterations(): array;
 
     /**
@@ -444,9 +336,6 @@ interface HawkSearchFieldInterface
      */
     public function setPreviewMapping(string $value);
 
-    /**
-     * @return bool
-     */
     public function getOmitTfAndPos(): bool;
 
     /**
@@ -454,9 +343,6 @@ interface HawkSearchFieldInterface
      */
     public function setOmitTfAndPos(bool $value);
 
-    /**
-     * @return string
-     */
     public function getCreateDate(): string;
 
     /**
@@ -464,9 +350,6 @@ interface HawkSearchFieldInterface
      */
     public function setCreateDate(string $value);
 
-    /**
-     * @return string
-     */
     public function getModifyDate(): string;
 
     /**

--- a/Block/System/Config/Logger/LogeLevels.php
+++ b/Block/System/Config/Logger/LogeLevels.php
@@ -22,6 +22,9 @@ use Monolog\Logger;
  */
 class LogeLevels implements \Magento\Framework\Option\ArrayInterface
 {
+    /**
+     * @return list<array{label: string, value: int}>
+     */
     public function toOptionArray()
     {
         return [

--- a/Compatibility/DeprecatedMessageBuilder.php
+++ b/Compatibility/DeprecatedMessageBuilder.php
@@ -52,7 +52,7 @@ class DeprecatedMessageBuilder
         $messageTemplateParts = [];
 
         foreach (self::PARTS_ORDER as $part) {
-            /** @var DataObject $partObject */
+            /** @var ?DataObject $partObject */
             $partObject = $this->_get($part);
             if (!$partObject || !$partObject->getFormat()) {
                 continue;

--- a/Compatibility/DeprecatedMessageBuilder.php
+++ b/Compatibility/DeprecatedMessageBuilder.php
@@ -99,7 +99,6 @@ class DeprecatedMessageBuilder
     /**
      * @param string $format
      * @param string[] $values
-     * @return DataObject
      */
     private function getPartObject(string $format, array $values = []): DataObject
     {

--- a/Compatibility/DeprecatedMessageBuilderInterface.php
+++ b/Compatibility/DeprecatedMessageBuilderInterface.php
@@ -27,35 +27,29 @@ interface DeprecatedMessageBuilderInterface
     /**
      * @param string $format
      * @param string[] $values
-     * @return self
      */
     public function setSincePart(string $format, array $values = []): self;
 
     /**
      * @param string $format
      * @param string[] $values
-     * @return self
      */
     public function setMainPart(string $format, array $values = []): self;
 
     /**
      * @param string $format
      * @param string[] $values
-     * @return self
      */
     public function setReplacementPart(string $format, array $values = []): self;
 
     /**
      * @param string $format
      * @param string[] $values
-     * @return self
      */
     public function setExtra(string $format, array $values = []): self;
 
     /**
      * Build a final message string
-     *
-     * @return string
      */
     public function build(): string;
 }

--- a/Compatibility/DeprecatedMessageTrigger.php
+++ b/Compatibility/DeprecatedMessageTrigger.php
@@ -16,6 +16,9 @@ namespace HawkSearch\Connector\Compatibility;
 
 class DeprecatedMessageTrigger implements DeprecatedMessageTriggerInterface
 {
+    /**
+     * @return void
+     */
     public function execute(string $message)
     {
         if ($message) {

--- a/Compatibility/DeprecatedMessageTriggerInterface.php
+++ b/Compatibility/DeprecatedMessageTriggerInterface.php
@@ -18,6 +18,8 @@ interface DeprecatedMessageTriggerInterface
 {
     /**
      * Trigger deprecation message
+     *
+     * @return void
      */
     public function execute(string $message);
 }

--- a/Compatibility/DeprecationUtility.php
+++ b/Compatibility/DeprecationUtility.php
@@ -16,19 +16,16 @@ namespace HawkSearch\Connector\Compatibility;
 
 use Magento\Framework\App\ObjectManager;
 
+/**
+ * @internal
+ */
 class DeprecationUtility
 {
-    /**
-     * @return DeprecatedMessageBuilderInterface
-     */
     public static function getMessageBuilder(): DeprecatedMessageBuilderInterface
     {
         return ObjectManager::getInstance()->get(DeprecatedMessageBuilderInterface::class);
     }
 
-    /**
-     * @return DeprecatedMessageTriggerInterface
-     */
     public static function getMessageTrigger(): DeprecatedMessageTriggerInterface
     {
         return ObjectManager::getInstance()->get(DeprecatedMessageTriggerInterface::class);

--- a/Compatibility/PublicMethodDeprecationTrait.php
+++ b/Compatibility/PublicMethodDeprecationTrait.php
@@ -86,6 +86,7 @@ trait PublicMethodDeprecationTrait
      * Triggers a deprecation message for a callable(protected or private) method and execute it.
      * If method isn't callable it throws a fatal error.
      * Method signature is in sync with {@see DataObject::__call}
+     * @return mixed
      */
     public function __call($methodName, $arguments) // @phpstan-ignore-line
     {

--- a/Compatibility/PublicPropertyDeprecationTrait.php
+++ b/Compatibility/PublicPropertyDeprecationTrait.php
@@ -168,7 +168,6 @@ trait PublicPropertyDeprecationTrait
     /**
      * @param string $propertyName
      * @param mixed[] $mainPartArgs
-     * @return string
      */
     private function buildPropertyDeprecationMessage(string $propertyName, array $mainPartArgs): string
     {

--- a/Gateway/Config/ApiConfigInterface.php
+++ b/Gateway/Config/ApiConfigInterface.php
@@ -25,7 +25,6 @@ interface ApiConfigInterface
      * Returns API url
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getApiUrl($store = null): string;
 
@@ -33,7 +32,6 @@ interface ApiConfigInterface
      * Returns API Bearer connection token
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getApiKey($store = null): string;
 }

--- a/Gateway/ErrorMapper/ErrorMessageMapperInterface.php
+++ b/Gateway/ErrorMapper/ErrorMessageMapperInterface.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\ErrorMapper;
 
-use Magento\Framework\Phrase;
-
 /**
  * Interface to provide customization for API validation errors.
+ *
  * @api
  */
 interface ErrorMessageMapperInterface
@@ -26,7 +25,7 @@ interface ErrorMessageMapperInterface
      * Returns customized error message by provided code.
      * If message not found `null` will be returned.
      *
-     * @return Phrase|null
+     * @return string
      */
     public function getMessage(string $code);
 }

--- a/Gateway/Helper/HttpResponseReader.php
+++ b/Gateway/Helper/HttpResponseReader.php
@@ -61,12 +61,6 @@ class HttpResponseReader
      */
     public function readResponseMessage(array $subject)
     {
-        if (!isset($subject[ClientInterface::RESPONSE_MESSAGE])
-            || !is_string($subject[ClientInterface::RESPONSE_MESSAGE])
-        ) {
-            throw new \InvalidArgumentException('Response message does not exist');
-        }
-
-        return $subject[ClientInterface::RESPONSE_MESSAGE];
+        return (string)($subject[ClientInterface::RESPONSE_MESSAGE] ?? '');
     }
 }

--- a/Gateway/Helper/HttpResponseReader.php
+++ b/Gateway/Helper/HttpResponseReader.php
@@ -16,16 +16,15 @@ declare(strict_types=1);
 namespace HawkSearch\Connector\Gateway\Helper;
 
 use HawkSearch\Connector\Gateway\Http\ClientInterface;
-use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 
 /**
  * @api
  * @since 2.11
  *
  * @todo get rid of this class in favour of HttpResultInterface
- * @see \HawkSearch\Connector\Gateway\Instruction\ResultInterface
+ * @see ClientInterface
  *
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class HttpResponseReader
 {

--- a/Gateway/Helper/SubjectReader.php
+++ b/Gateway/Helper/SubjectReader.php
@@ -15,21 +15,23 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Helper;
 
-use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
+use HawkSearch\Connector\Gateway\Validator\ValidatorInterface;
 
 /**
  * @api
  * @since 2.11
  *
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
+ * @phpstan-import-type ValidationSubject from ValidatorInterface
  */
 class SubjectReader
 {
     /**
-     * @param HttpResult $subject
-     * @return array
+     * @param ValidationSubject $subject
+     * @return HttpResult
      * @todo get rid of this method in favour of HttpResultInterface
-     * @see \HawkSearch\Connector\Gateway\Instruction\ResultInterface
+     * @see ClientInterface
      */
     public function readResponse(array $subject)
     {

--- a/Gateway/Http/Client.php
+++ b/Gateway/Http/Client.php
@@ -42,7 +42,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     public function placeRequest(TransferInterface $transferObject)
     {
@@ -97,7 +97,7 @@ class Client implements ClientInterface
 
             $responseData[self::RESPONSE_DATA] = $this->converter->convert($response->getBody());
             $responseData[self::RESPONSE_CODE] = $response->getStatusCode();
-            $responseData[self::RESPONSE_MESSAGE] = $response->getReasonPhrase();
+            $responseData[self::RESPONSE_MESSAGE] = (string)$response->getReasonPhrase();
 
             $this->logger->info(
                 'Api Client Response:',

--- a/Gateway/Http/Client.php
+++ b/Gateway/Http/Client.php
@@ -106,7 +106,7 @@ class Client implements ClientInterface
                     'message' => $responseData[self::RESPONSE_MESSAGE],
                 ]
             );
-            $this->logger->debug('Response Body:', (array)$responseData[self::RESPONSE_DATA]);
+            $this->logger->debug('Response Body:', $responseData[self::RESPONSE_DATA]);
         } catch (RuntimeException $e) {
             $message = $e->getMessage();
             if ($e->getCode()) {

--- a/Gateway/Http/ClientInterface.php
+++ b/Gateway/Http/ClientInterface.php
@@ -18,13 +18,10 @@ namespace HawkSearch\Connector\Gateway\Http;
  * Interface ClientInterface
  * Http client interface
  *
- * @phpstan-type keyCode self::RESPONSE_CODE
- * @phpstan-type keyMessage self::RESPONSE_MESSAGE
- * @phpstan-type keyData self::RESPONSE_DATA
  * @phpstan-type HttpResult array{
- *      keyCode: int,
- *      keyMessage: string,
- *      keyData: mixed,
+ *      code: int,
+ *      message: string,
+ *      response: mixed,
  *  }|array{}
  * @api
  * @todo Remove empty array definition for HttpResult phpstan type

--- a/Gateway/Http/ClientInterface.php
+++ b/Gateway/Http/ClientInterface.php
@@ -18,7 +18,17 @@ namespace HawkSearch\Connector\Gateway\Http;
  * Interface ClientInterface
  * Http client interface
  *
+ * @phpstan-type keyCode self::RESPONSE_CODE
+ * @phpstan-type keyMessage self::RESPONSE_MESSAGE
+ * @phpstan-type keyData self::RESPONSE_DATA
+ * @phpstan-type HttpResult array{
+ *      keyCode: int,
+ *      keyMessage: string,
+ *      keyData: mixed,
+ *  }|array{}
  * @api
+ * @todo Remove empty array definition for HttpResult phpstan type
+ * @todo Replace HttpResult phpstan iterable type with a new HttpResultInterface type
  */
 interface ClientInterface
 {
@@ -29,7 +39,7 @@ interface ClientInterface
     /**
      * Places request to gateway. Returns result as ENV array
      *
-     * @return array
+     * @return HttpResult
      */
     public function placeRequest(TransferInterface $transferObject);
 }

--- a/Gateway/Http/Converter/JsonToArray.php
+++ b/Gateway/Http/Converter/JsonToArray.php
@@ -30,16 +30,11 @@ class JsonToArray implements ConverterInterface
         $this->json = $json;
     }
 
-    public function convert($response)
+    /**
+     * @return array
+     */
+    public function convert(string $response)
     {
-        if (!is_string($response)) {
-            throw new \InvalidArgumentException(__('The response type is incorrect. Verify the type and try again.')->render());
-        }
-
-        if ($response === '') {
-            $response = '{}';
-        }
-
-        return $this->json->unserialize($response);
+        return (array)$this->json->unserialize($response);
     }
 }

--- a/Gateway/Http/Converter/JsonToArray.php
+++ b/Gateway/Http/Converter/JsonToArray.php
@@ -31,7 +31,7 @@ class JsonToArray implements ConverterInterface
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     public function convert(string $response)
     {

--- a/Gateway/Http/ConverterInterface.php
+++ b/Gateway/Http/ConverterInterface.php
@@ -10,21 +10,19 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
 namespace HawkSearch\Connector\Gateway\Http;
 
 /**
- * Interface ConverterInterface
  * @api
  * @since 2.11
  */
 interface ConverterInterface
 {
     /**
-     * Converts gateway response to ENV structure
+     * Converts gateway response to a desired structure
      *
-     * @param mixed $response
-     * @return array
-     * @throws \InvalidArgumentException
+     * @return mixed
      */
-    public function convert($response);
+    public function convert(string $response);
 }

--- a/Gateway/Http/Transfer.php
+++ b/Gateway/Http/Transfer.php
@@ -76,9 +76,7 @@ class Transfer implements TransferInterface
     }
 
     /**
-     * Returns gateway client configuration
-     *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getClientConfig()
     {
@@ -86,8 +84,6 @@ class Transfer implements TransferInterface
     }
 
     /**
-     * Returns method used to place request
-     *
      * @return string
      */
     public function getMethod()
@@ -96,23 +92,22 @@ class Transfer implements TransferInterface
     }
 
     /**
-     * Returns headers
-     *
-     * @return array
+     * @return array<array-key, mixed>
      */
     public function getHeaders()
     {
         return $this->headers;
     }
 
+    /**
+     * @return RequestSubject
+     */
     public function getBody()
     {
         return $this->body;
     }
 
     /**
-     * Returns URI
-     *
      * @return string
      */
     public function getUri()
@@ -129,8 +124,6 @@ class Transfer implements TransferInterface
     }
 
     /**
-     * Returns Auth username
-     *
      * @return string
      */
     public function getAuthUsername()
@@ -139,8 +132,6 @@ class Transfer implements TransferInterface
     }
 
     /**
-     * Returns Auth password
-     *
      * @return string
      */
     public function getAuthPassword()

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -57,6 +57,9 @@ class TransferFactory implements TransferFactoryInterface
         $this->uriBuilder = $uriBuilder ?? $uriBuilderFactory->create();
     }
 
+    /**
+     * @return TransferInterface
+     */
     public function create(array $request)
     {
         return $this->transferBuilder

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -27,7 +27,6 @@ class TransferFactory implements TransferFactoryInterface
 {
     private TransferBuilder $transferBuilder;
     private ApiConfigInterface $apiConfig;
-    private RequestInterface $httpRequest;
     private ConnectionScopeResolver $connectionScopeResolver;
     private string $path;
     private string $method;
@@ -37,7 +36,7 @@ class TransferFactory implements TransferFactoryInterface
     public function __construct(
         TransferBuilder $transferBuilder,
         ApiConfigInterface $apiConfig,
-        RequestInterface $httpRequest,
+        RequestInterface $httpRequest, // @todo remove $httpRequest argument
         UriBuilderFactory $uriBuilderFactory,
         BuilderInterfaceFactory $builderInterfaceFactory,
         ConnectionScopeResolver $connectionScopeResolver,
@@ -49,7 +48,6 @@ class TransferFactory implements TransferFactoryInterface
     {
         $this->transferBuilder = $transferBuilder;
         $this->apiConfig = $apiConfig;
-        $this->httpRequest = $httpRequest;
         $this->connectionScopeResolver = $connectionScopeResolver;
         $this->path = $path;
         $this->method = $method;

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -76,10 +76,8 @@ class TransferFactory implements TransferFactoryInterface
 
     /**
      * Get Full URL based on relative URL.
-     *
-     * @return string
      */
-    private function buildFullApiUrl()
+    private function buildFullApiUrl(): string
     {
         return $this->uriBuilder->build(
             $this->apiConfig->getApiUrl($this->connectionScopeResolver->resolve()->getId()),

--- a/Gateway/Http/TransferInterface.php
+++ b/Gateway/Http/TransferInterface.php
@@ -23,23 +23,19 @@ namespace HawkSearch\Connector\Gateway\Http;
 interface TransferInterface
 {
     /**
-     * Returns gateway client configuration
-     *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getClientConfig();
 
     /**
-     * Returns method used to place request
+     * Returns HTTP method used to place request
      *
-     * @return string|int
+     * @return string
      */
     public function getMethod();
 
     /**
-     * Returns headers
-     *
-     * @return array
+     * @return array<array-key, mixed>
      */
     public function getHeaders();
 
@@ -51,29 +47,21 @@ interface TransferInterface
     public function shouldEncode();
 
     /**
-     * Returns request body
-     *
      * @return RequestSubject
      */
     public function getBody();
 
     /**
-     * Returns URI
-     *
      * @return string
      */
     public function getUri();
 
     /**
-     * Returns Auth username
-     *
      * @return string
      */
     public function getAuthUsername();
 
     /**
-     * Returns Auth password
-     *
      * @return string
      */
     public function getAuthPassword();

--- a/Gateway/Http/Uri/UriBuilderInterface.php
+++ b/Gateway/Http/Uri/UriBuilderInterface.php
@@ -21,10 +21,5 @@ namespace HawkSearch\Connector\Gateway\Http\Uri;
  */
 interface UriBuilderInterface
 {
-    /**
-     * Builds API Url
-     *
-     * @return string
-     */
     public function build(string $url, string $path): string;
 }

--- a/Gateway/Instruction/GatewayInstruction.php
+++ b/Gateway/Instruction/GatewayInstruction.php
@@ -93,7 +93,7 @@ class GatewayInstruction implements InstructionInterface
      *
      * @throws InstructionException
      */
-    private function processErrors(ResultInterface $result)
+    private function processErrors(ResultInterface $result): void
     {
         $messages = [];
         $errorsSource = array_merge($result->getErrorCodes(), $result->getFailsDescription());

--- a/Gateway/Instruction/GatewayInstruction.php
+++ b/Gateway/Instruction/GatewayInstruction.php
@@ -56,6 +56,10 @@ class GatewayInstruction implements InstructionInterface
         $this->errorMessageMapper = $errorMessageMapper;
     }
 
+    /**
+     * @return \HawkSearch\Connector\Gateway\Instruction\ResultInterface
+     * @throws InstructionException
+     */
     public function execute(array $requestSubject)
     {
         // @TODO implement exceptions catching
@@ -97,7 +101,7 @@ class GatewayInstruction implements InstructionInterface
             $errorCodeOrMessage = (string)$errorCodeOrMessage;
 
             if (isset($this->errorMessageMapper)) {
-                $mapped = (string)$this->errorMessageMapper->getMessage($errorCodeOrMessage);
+                $mapped = $this->errorMessageMapper->getMessage($errorCodeOrMessage);
                 if (!empty($mapped)) {
                     $messages[] = $mapped;
                     $errorCodeOrMessage = $mapped;

--- a/Gateway/Instruction/InstructionManager.php
+++ b/Gateway/Instruction/InstructionManager.php
@@ -37,6 +37,9 @@ class InstructionManager implements InstructionManagerInterface
         $this->instructionPool = $instructionPool;
     }
 
+    /**
+     * @return ResultInterface
+     */
     public function executeByCode(string $instructionCode, array $arguments = [])
     {
         return $this->instructionPool
@@ -44,6 +47,9 @@ class InstructionManager implements InstructionManagerInterface
             ->execute($arguments);
     }
 
+    /**
+     * @return ResultInterface
+     */
     public function execute(InstructionInterface $instruction, array $arguments = [])
     {
         return $instruction->execute($arguments);

--- a/Gateway/Instruction/InstructionManagerPool.php
+++ b/Gateway/Instruction/InstructionManagerPool.php
@@ -49,6 +49,9 @@ class InstructionManagerPool implements InstructionManagerPoolInterface
         );
     }
 
+    /**
+     * @return InstructionManagerInterface
+     */
     public function get(string $instructionProviderCode)
     {
         if (!isset($this->executors[$instructionProviderCode])) {

--- a/Gateway/Instruction/InstructionPool.php
+++ b/Gateway/Instruction/InstructionPool.php
@@ -51,6 +51,9 @@ class InstructionPool implements InstructionPoolInterface
         );
     }
 
+    /**
+     * @return InstructionInterface
+     */
     public function get(string $instructionCode)
     {
         if (!isset($this->instructions[$instructionCode])) {

--- a/Gateway/Instruction/Result/ArrayResult.php
+++ b/Gateway/Instruction/Result/ArrayResult.php
@@ -15,13 +15,14 @@ declare(strict_types=1);
 namespace HawkSearch\Connector\Gateway\Instruction\Result;
 
 use HawkSearch\Connector\Gateway\Helper\HttpResponseReader;
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 
 /**
  * @api
  * @since 2.11
  *
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class ArrayResult implements ResultInterface
 {
@@ -46,7 +47,7 @@ class ArrayResult implements ResultInterface
     /**
      * Returns result interpretation
      *
-     * @return array
+     * @return array<mixed>
      */
     public function get()
     {

--- a/Gateway/Instruction/Result/DefaultResult.php
+++ b/Gateway/Instruction/Result/DefaultResult.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Instruction\Result;
 
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
 use HawkSearch\Connector\Gateway\Instruction\ResultInterface;
 
 /**
  * @api
  * @since 2.11
  *
- * @phpstan-import-type HttpResult from ResultInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  */
 class DefaultResult implements ResultInterface
 {
@@ -38,7 +39,7 @@ class DefaultResult implements ResultInterface
     }
 
     /**
-     * @inheriDoc
+     * @return HttpResult
      */
     public function get()
     {

--- a/Gateway/Instruction/ResultInterface.php
+++ b/Gateway/Instruction/ResultInterface.php
@@ -14,18 +14,8 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Instruction;
 
-use HawkSearch\Connector\Gateway\Http\ClientInterface;
-
 /**
  * @api
- *
- * @phpstan-type HttpResult array{
- *     'code': int,
- *     'message': string,
- *     'response': mixed
- * }|array{}
- * @todo Remove empty array definition for HttpResult phpstan type
- * @todo Replace HttpResult phpstan iterable type with a new HttpResultInterface type
  */
 interface ResultInterface
 {

--- a/Gateway/Request/ApiKeyAuthHeader.php
+++ b/Gateway/Request/ApiKeyAuthHeader.php
@@ -30,6 +30,9 @@ class ApiKeyAuthHeader implements BuilderInterface
         $this->connectionScopeResolver = $connectionScopeResolver;
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function build(array $buildSubject)
     {
         return [

--- a/Gateway/Request/BuilderComposite.php
+++ b/Gateway/Request/BuilderComposite.php
@@ -50,6 +50,9 @@ class BuilderComposite implements BuilderInterface
         );
     }
 
+    /**
+     * @return RequestSubject
+     */
     public function build(array $buildSubject)
     {
         $result = [];

--- a/Gateway/Request/FieldDataBuilder.php
+++ b/Gateway/Request/FieldDataBuilder.php
@@ -31,7 +31,7 @@ class FieldDataBuilder implements BuilderInterface
     }
 
     /**
-     * Builds ENV request
+     * @return mixed[]
      */
     public function build(array $buildSubject)
     {
@@ -39,7 +39,7 @@ class FieldDataBuilder implements BuilderInterface
         $hawkSearchField = $this->hawkSearchFieldFactory->create();
         $hawkSearchField->addData($buildSubject);
 
-        /** @var array<array-key, mixed> */
+        /** @var mixed[] */
         return $hawkSearchField->getData();
     }
 }

--- a/Gateway/Request/StrictDataBuilder.php
+++ b/Gateway/Request/StrictDataBuilder.php
@@ -22,6 +22,8 @@ class StrictDataBuilder implements BuilderInterface
 {
     /**
      * Build request without data conversion
+     *
+     * @return mixed[]
      */
     public function build(array $buildSubject)
     {

--- a/Gateway/Response/FieldHandler.php
+++ b/Gateway/Response/FieldHandler.php
@@ -30,6 +30,9 @@ class FieldHandler implements HandlerInterface
         $this->fieldFactory = $fieldFactory;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function handle(array $handlingSubject, array $response)
     {
         if (isset($response[ClientInterface::RESPONSE_DATA])) {

--- a/Gateway/Response/FieldsListHandler.php
+++ b/Gateway/Response/FieldsListHandler.php
@@ -33,6 +33,9 @@ class FieldsListHandler implements HandlerInterface
         $this->fieldFactory = $fieldFactory;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function handle(array $handlingSubject, array $response)
     {
         if (isset($response[ClientInterface::RESPONSE_DATA]) && is_array($response[ClientInterface::RESPONSE_DATA])) {

--- a/Gateway/Response/HandlerChain.php
+++ b/Gateway/Response/HandlerChain.php
@@ -47,6 +47,9 @@ class HandlerChain implements HandlerInterface
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function handle(array $handlingSubject, array $response)
     {
         foreach ($this->handlers as $handler) {

--- a/Gateway/Response/HandlerInterface.php
+++ b/Gateway/Response/HandlerInterface.php
@@ -14,11 +14,14 @@ declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Response;
 
+use HawkSearch\Connector\Gateway\Http\ClientInterface;
+use HawkSearch\Connector\Gateway\InstructionInterface;
+
 /**
  * @api
  *
- * @phpstan-import-type RequestSubject from \HawkSearch\Connector\Gateway\InstructionInterface
- * @phpstan-import-type HttpResult from \HawkSearch\Connector\Gateway\Instruction\ResultInterface
+ * @phpstan-import-type RequestSubject from InstructionInterface
+ * @phpstan-import-type HttpResult from ClientInterface
  * @todo replace RequestSubject pseudo type by RequestInterface
  */
 interface HandlerInterface
@@ -28,7 +31,7 @@ interface HandlerInterface
      *
      * @param RequestSubject $handlingSubject
      * @param HttpResult $response
-     * @return array
+     * @return HttpResult
      */
     public function handle(array $handlingSubject, array $response);
 }

--- a/Helper/DataObjectHelper.php
+++ b/Helper/DataObjectHelper.php
@@ -25,7 +25,7 @@ class DataObjectHelper
      * Recursively converts associative array's key names from camelCase to snake_case.
      *
      * @param array<array-key, mixed> $data
-     * @return array
+     * @return array<array-key, mixed>
      */
     public function convertArrayToSnakeCase(array $data)
     {
@@ -56,7 +56,7 @@ class DataObjectHelper
     }
 
     /**
-     * @return string[][]
+     * @return list<list<string>>
      */
     protected function getPatternAndReplacement(): array
     {

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -117,7 +117,7 @@ class Url
     /**
      * Explodes path parts from an uri string
      *
-     * @return array
+     * @return string[]
      */
     protected function explodeUriPath(string $path)
     {
@@ -130,7 +130,7 @@ class Url
      * Clean empty parts in the path
      *
      * @param string[] $pathParts
-     * @return array
+     * @return string[]
      */
     protected function filterPathParts(array $pathParts)
     {
@@ -156,7 +156,7 @@ class Url
      */
     protected function isTrailingSlashInPath(string $path)
     {
-        return substr($path, -1) == '/';
+        return substr($path, -1) === '/';
     }
 
     /**

--- a/Logger/LoggerConfig.php
+++ b/Logger/LoggerConfig.php
@@ -33,6 +33,9 @@ class LoggerConfig implements LoggerConfigInterface
         $this->loggerXmlConfig = $loggerXmlConfig;
     }
 
+    /**
+     * @return bool
+     */
     public function isEnabled()
     {
         return $this->loggerXmlConfig->isEnabled();

--- a/Logger/LoggerConfigInterface.php
+++ b/Logger/LoggerConfigInterface.php
@@ -27,6 +27,7 @@ interface LoggerConfigInterface
 
     /**
      * Is logger enabled
+     *
      * @return  bool
      */
     public function isEnabled();
@@ -38,7 +39,7 @@ interface LoggerConfigInterface
 
     /**
      * @param MonologLoggerLevel $level
-     * @return self
+     * @return $this
      */
     public function setLogLevel(int $level);
 }

--- a/Logger/LoggerFactory.php
+++ b/Logger/LoggerFactory.php
@@ -18,6 +18,7 @@ use HawkSearch\Connector\Logger\Handler\Debug as DebugHandler;
 use Magento\Framework\ObjectManagerInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger as MonologLogger;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -42,6 +43,9 @@ class LoggerFactory implements LoggerFactoryInterface
         $this->instanceName = $instanceName;
     }
 
+    /**
+     * @return LoggerInterface
+     */
     public function create()
     {
         if (!$this->loggerConfig->isEnabled()) {

--- a/Logger/LoggerFactoryInterface.php
+++ b/Logger/LoggerFactoryInterface.php
@@ -23,8 +23,6 @@ use Psr\Log\LoggerInterface;
 interface LoggerFactoryInterface
 {
     /**
-     * Create logger instance
-     *
      * @return LoggerInterface
      */
     public function create();

--- a/Model/Config/ApiSettings.php
+++ b/Model/Config/ApiSettings.php
@@ -173,7 +173,6 @@ class ApiSettings extends ConfigProvider
      *
      * @param string $path Config path part
      * @param null|int|string $store
-     * @return string
      */
     private function getEnvironmentConfig(string $path, $store = null): string
     {

--- a/Model/Config/ApiSettings.php
+++ b/Model/Config/ApiSettings.php
@@ -35,7 +35,6 @@ class ApiSettings extends ConfigProvider
      * Get Api key
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getApiKey($store = null): string
     {
@@ -46,7 +45,6 @@ class ApiSettings extends ConfigProvider
      * Get Engine Name
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getEngineName($store = null): string
     {
@@ -57,7 +55,6 @@ class ApiSettings extends ConfigProvider
      * Get Hawksearch Environment
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getEnvironment($store = null): string
     {
@@ -86,7 +83,6 @@ class ApiSettings extends ConfigProvider
      * Get Client Guid / Tracking Key
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getClientGuid($store = null): string
     {
@@ -97,7 +93,6 @@ class ApiSettings extends ConfigProvider
      * Get Hawksearch Lucene Engine Reference URL
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getHawkUrl($store = null): string
     {
@@ -108,7 +103,6 @@ class ApiSettings extends ConfigProvider
      * Get Hawksearch Tracking URL
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getTrackingUrl($store = null): string
     {
@@ -119,7 +113,6 @@ class ApiSettings extends ConfigProvider
      * Get Hawksearch Recommendations URL
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getRecommendationsUrl($store = null): string
     {
@@ -139,7 +132,6 @@ class ApiSettings extends ConfigProvider
      * Get Hawksearch Dashboard API URL
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getDashboardApiUrl($store = null): string
     {
@@ -150,7 +142,6 @@ class ApiSettings extends ConfigProvider
      * Get Hawksearch Workbench URL
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getHawksearchWorkbenchUrl($store = null): string
     {
@@ -161,7 +152,6 @@ class ApiSettings extends ConfigProvider
      * Get Hawksearch Indexing API URL
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getIndexingApiUrl($store = null): string
     {
@@ -172,7 +162,6 @@ class ApiSettings extends ConfigProvider
      * Get Hawksearch Search API URL
      *
      * @param null|int|string $store
-     * @return string
      */
     public function getSearchApiUrl($store = null): string
     {

--- a/Model/Config/Logger.php
+++ b/Model/Config/Logger.php
@@ -25,7 +25,6 @@ class Logger extends ConfigProvider
      * Check if logging is enabled for selected store
      *
      * @param null|int|string $store
-     * @return bool
      */
     public function isEnabled($store = null): bool
     {
@@ -36,7 +35,6 @@ class Logger extends ConfigProvider
      * Get log level
      *
      * @param null|int|string $store
-     * @return int
      */
     public function getLogLevel($store = null): int
     {

--- a/Model/Config/Source/Api/Environment.php
+++ b/Model/Config/Source/Api/Environment.php
@@ -22,6 +22,9 @@ use Magento\Framework\Data\OptionSourceInterface;
  */
 class Environment implements OptionSourceInterface
 {
+    /**
+     * @return list<array{label: \Stringable, value: string}>
+     */
     public function toOptionArray(): array
     {
         return [

--- a/Model/ConfigProvider.php
+++ b/Model/ConfigProvider.php
@@ -50,6 +50,9 @@ class ConfigProvider implements ConfigProviderInterface
         return $this->configRootPath . '/' . $this->configGroup . '/' . $path;
     }
 
+    /**
+     * @return mixed
+     */
     public function getConfig(string $path, $scopeId = null, string $scope = ScopeInterface::SCOPE_STORES)
     {
         return $this->scopeConfig->getValue(

--- a/Model/HawkSearchField.php
+++ b/Model/HawkSearchField.php
@@ -521,6 +521,9 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::TAGS, $value);
     }
 
+    /**
+     * @return int[]
+     */
     public function getIterations(): array
     {
         return $this->getData(static::ITERATIONS);

--- a/Model/HawkSearchField.php
+++ b/Model/HawkSearchField.php
@@ -66,9 +66,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         parent::__construct($data);
     }
 
-    /**
-     * @return int
-     */
     public function getFieldId(): int
     {
         return (int)$this->getData(static::FIELD_ID);
@@ -82,9 +79,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::FIELD_ID, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getSyncGuid(): string
     {
         return $this->getData(static::SYNC_GUID);
@@ -98,9 +92,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::SYNC_GUID, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->getData(static::NAME);
@@ -114,9 +105,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::NAME, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getFieldType(): string
     {
         return $this->getData(static::FIELD_TYPE);
@@ -130,9 +118,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::FIELD_TYPE, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getLabel(): string
     {
         return $this->getData(static::LABEL);
@@ -146,9 +131,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::LABEL, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return $this->getData(static::TYPE);
@@ -162,9 +144,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::TYPE, $value);
     }
 
-    /**
-     * @return int
-     */
     public function getBoost(): int
     {
         return $this->getData(static::BOOST);
@@ -178,9 +157,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::BOOST, $value);
     }
 
-    /**
-     * @return int
-     */
     public function getFacetHandler(): int
     {
         return $this->getData(static::FACET_HANDLER);
@@ -194,9 +170,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::FACET_HANDLER, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsPrimaryKey(): bool
     {
         return $this->getData(static::IS_PRIMARY_KEY);
@@ -210,9 +183,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_PRIMARY_KEY, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsOutput(): bool
     {
         return $this->getData(static::IS_OUTPUT);
@@ -226,9 +196,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_OUTPUT, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsShingle(): bool
     {
         return $this->getData(static::IS_SHINGLE);
@@ -242,9 +209,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_SHINGLE, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsBestFragment(): bool
     {
         return $this->getData(static::IS_BEST_FRAGMENT);
@@ -258,9 +222,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_BEST_FRAGMENT, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsDictionary(): bool
     {
         return $this->getData(static::IS_DICTIONARY);
@@ -274,9 +235,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_DICTIONARY, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsSort(): bool
     {
         return $this->getData(static::IS_SORT);
@@ -290,9 +248,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_SORT, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsPrefix(): bool
     {
         return $this->getData(static::IS_PREFIX);
@@ -306,9 +261,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_PREFIX, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsHidden(): bool
     {
         return $this->getData(static::IS_HIDDEN);
@@ -322,9 +274,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_HIDDEN, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsCompare(): bool
     {
         return $this->getData(static::IS_COMPARE);
@@ -338,9 +287,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_COMPARE, $value);
     }
 
-    /**
-     * @return int
-     */
     public function getSortOrder(): int
     {
         return $this->getData(static::SORT_ORDER);
@@ -354,9 +300,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::SORT_ORDER, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getPartialQuery(): string
     {
         return $this->getData(static::PARTIAL_QUERY);
@@ -370,9 +313,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::PARTIAL_QUERY, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsKeywordText(): bool
     {
         return $this->getData(static::IS_KEYWORD_TEXT);
@@ -386,9 +326,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_KEYWORD_TEXT, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsQuery(): bool
     {
         return $this->getData(static::IS_QUERY);
@@ -402,9 +339,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_QUERY, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getIsQueryText(): bool
     {
         return $this->getData(static::IS_QUERY_TEXT);
@@ -418,9 +352,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::IS_QUERY_TEXT, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getSkipCustom(): bool
     {
         return $this->getData(static::SKIP_CUSTOM);
@@ -434,9 +365,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::SKIP_CUSTOM, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getStripHtml(): bool
     {
         return $this->getData(static::STRIP_HTML);
@@ -450,9 +378,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::STRIP_HTML, $value);
     }
 
-    /**
-     * @return int
-     */
     public function getMinNGramAnalyzer(): int
     {
         return $this->getData(static::MIN_N_GRAM_ANALYZER);
@@ -466,9 +391,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::MIN_N_GRAM_ANALYZER, $value);
     }
 
-    /**
-     * @return int
-     */
     public function getMaxNGramAnalyzer(): int
     {
         return $this->getData(static::MAX_N_GRAM_ANALYZER);
@@ -482,9 +404,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::MAX_N_GRAM_ANALYZER, $value);
     }
 
-    /**
-     * @return int
-     */
     public function getCoordinateType(): int
     {
         return $this->getData(static::COORDINATE_TYPE);
@@ -498,9 +417,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::COORDINATE_TYPE, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getOmitNorms(): bool
     {
         return $this->getData(static::OMIT_NORMS);
@@ -514,9 +430,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::OMIT_NORMS, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getItemMapping(): string
     {
         return $this->getData(static::ITEM_MAPPING);
@@ -530,9 +443,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::ITEM_MAPPING, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getDefaultValue(): string
     {
         return $this->getData(static::DEFAULT_VALUE);
@@ -546,9 +456,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::DEFAULT_VALUE, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getUseForPrediction(): bool
     {
         return $this->getData(static::USE_FOR_PREDICTION);
@@ -562,9 +469,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::USE_FOR_PREDICTION, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getCopyTo(): string
     {
         return $this->getData(static::COPY_TO);
@@ -578,9 +482,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::COPY_TO, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getAnalyzer(): string
     {
         return $this->getData(static::ANALYZER);
@@ -594,9 +495,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::ANALYZER, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getDoNotStore(): bool
     {
         return $this->getData(static::DO_NOT_STORE);
@@ -610,9 +508,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::DO_NOT_STORE, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getTags(): string
     {
         return $this->getData(static::TAGS);
@@ -626,9 +521,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::TAGS, $value);
     }
 
-    /**
-     * @return array
-     */
     public function getIterations(): array
     {
         return $this->getData(static::ITERATIONS);
@@ -671,9 +563,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::PREVIEW_MAPPING, $value);
     }
 
-    /**
-     * @return bool
-     */
     public function getOmitTfAndPos(): bool
     {
         return $this->getData(static::OMIT_TF_ADN_POS);
@@ -687,9 +576,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::OMIT_TF_ADN_POS, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getCreateDate(): string
     {
         return $this->getData(static::CREATE_DATE);
@@ -703,9 +589,6 @@ class HawkSearchField extends DataObject implements HawkSearchFieldInterface
         return $this->setData(static::CREATE_DATE, $value);
     }
 
-    /**
-     * @return string
-     */
     public function getModifyDate(): string
     {
         return $this->getData(static::MODIFY_DATE);

--- a/Setup/Patch/Data/ApiUrlConfigPatch.php
+++ b/Setup/Patch/Data/ApiUrlConfigPatch.php
@@ -41,17 +41,24 @@ class ApiUrlConfigPatch implements DataPatchInterface
         $this->patcher = $patcher;
     }
 
+    /**
+     * @return string[]
+     */
     public static function getDependencies()
     {
         return [];
     }
 
+    /**
+     * @return string[]
+     */
     public function getAliases()
     {
         return [];
     }
 
     /**
+     * @return $this
      * @throws LocalizedException
      */
     public function apply()


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 2.11
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes (with the help of `DebugClassLoader` class)
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | Ref HC-1706

This PR attempts to add `@return` annotartions on public/protected methods and turn `@return` annotations on private methods into return type declarations. With the help of Symfony's `patch-type-declarations` script.

This is not a breaking change. The goal is to turn every `@return` phpDoc annotation to return type declaration on as many methods as possible on version 3.0

This PR also provided some fixes on types mismatches. 

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained stable branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too). Lowest stable is `master` now.
 - Features and deprecations must be submitted against the latest branch. Latest is a branch for active development.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow (doc link will be added later)
 - Never break backward compatibility (see https://developerdocs.hawksearch.com/docs/magento-developers-bc-policy).
-->
