### PR TITLE
feat: add wrapper for symfony patch-type-declarations script

### DIFF
--- a/bin/magento-patch-type-declarations
+++ b/bin/magento-patch-type-declarations
@@ -1,0 +1,40 @@
+#!/usr/bin/env php
+<?php
+/**
+ * This file is a wrapper for Symfony's patch-type-declarations script.
+ * It used to autoload ObjectManager
+ */
+
+if ('cli' !== \PHP_SAPI) {
+    throw new Exception('This script must be run from the command line.');
+}
+
+$autoloadPaths = [
+    // run script from MAGENTO_ROOT
+    getcwd() . '/vendor/autoload.php',
+    // script is located in MAGENTO_ROOT/vendor/hawksearch/connector/bin
+    __DIR__ . '/../../../autoload.php',
+    // script is located in MAGENTO_ROOT/app/code/HawkSearch/Connector/bin
+    __DIR__ . '/../../../../../vendor/autoload.php',
+    // script is located in MAGENTO_ROOT/ext/hawksearch/connector/bin
+    __DIR__ . '/../../../../vendor/autoload.php'
+];
+
+$vendorPath = '';
+do {
+    $path = current($autoloadPaths);
+    if (file_exists($path)) {
+        $vendorPath = dirname($path);
+        break;
+    }
+} while (next($autoloadPaths));
+
+if (!$vendorPath) {
+    fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
+    exit(1);
+}
+
+require $vendorPath . '/../app/autoload.php';
+$bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
+
+include $vendorPath . '/symfony/error-handler/Resources/bin/patch-type-declarations';

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
         "allow-plugins": {
             "phpstan/extension-installer": true
         }
-    }
+    },
+    "bin": [
+        "bin/magento-patch-type-declarations"
+    ]
 }


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 2.11 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | no
| Tickets       | Ref HC-1703

Adding wrapper for Symfony `patch-type-declarations` script. Wrapper helps to init `ObjectManager`

`patch-type-declarations` script helps to display deprecations for incompatible return types and fix them.

See native Symfony documentation on how to use the script 
https://symfony.com/blog/symfony-7-0-type-declarations
https://symfony.com/doc/6.4/setup/upgrade_major.html#upgrading-to-symfony-6-add-native-return-types

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained stable branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too). Lowest stable is `master` now.
 - Features and deprecations must be submitted against the latest branch. Latest is a branch for active development.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow (doc link will be added later)
 - Never break backward compatibility (see https://developerdocs.hawksearch.com/docs/magento-developers-bc-policy).
-->
