### PR TITLE
feat: add support for PHP 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "AFL-3.0"
     ],
     "require": {
-        "php": "^7.2|~8.0.0|~8.1.0|~8.2.0",
+        "php": "^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0",
         "magento/framework": "^102.0.5|^103.0",
         "magento/magento-composer-installer": "*"
     },


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 2.11 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | Ref HC-1467

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained stable branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too). Lowest stable is `master` now.
 - Features and deprecations must be submitted against the latest branch. Latest is a branch for active development.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow (doc link will be added later)
 - Never break backward compatibility (see https://developerdocs.hawksearch.com/docs/magento-developers-bc-policy).
-->

Extending PHP dependency up to 8.3 because Magento 2.4.7 has native support for it