### PR TITLE
feat: drop min required version to PHP 8.1, Magento 2.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # HawkSearch API Connector module for Magento Open Source and Adobe Commerce
+
+This is a required dependency for any extension which uses connections with HawkSearch API.
+The extension provides a layer which helps to create an API communication endpoint. 
+
+## Documentation
+
+Check out our [Getting Started](https://developerdocs.hawksearch.com/docs/magento-getting-started) guide and start using [HawkSearch](https://www.hawksearch.com/ ) for Magento 2.
+
+## Platform Version Support
+
+* Magento Open Source: **2.4.4 - 2.4.7**
+* Adobe Commerce: **2.4.4 - 2.4.7**

--- a/UPGRADE-2.11.md
+++ b/UPGRADE-2.11.md
@@ -1,0 +1,5 @@
+# UPGRADE FROM 2.10 to 2.11
+
+## Steps to action
+
+- Upgrade your Magento store at least to version 2.4.4 and PHP to version 8.1

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,0 +1,3 @@
+# UPGRADE FROM 2.x to 3.0
+
+## Steps to action

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "AFL-3.0"
     ],
     "require": {
-        "php": "^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0",
-        "magento/framework": "^102.0.5|^103.0",
+        "php": "~8.1.0|~8.2.0|~8.3.0",
+        "magento/framework": "^103.0.4",
         "magento/magento-composer-installer": "*"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 2.11
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| BC breaks?    | yes/no (implicit BC for stores using older PHP and Magento framework)
| Tests pass?   | yes
| Tickets       | Fix HC-1711

We've started adding PHP type hints in the 0.8 release to all methods and properties. A new `mixed` type was added in PHP 8.0 which is used widely in HawkSarch classes. The other reason to drop off compatibility with PHP 7.4 is the fact that the minimum supported Magento version is 2.4.4
