### PR TITLE
refactor: add missing strict types declaration

### DIFF
--- a/Gateway/Http/Converter/JsonToArray.php
+++ b/Gateway/Http/Converter/JsonToArray.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Http\Converter;
 

--- a/Gateway/Http/ConverterInterface.php
+++ b/Gateway/Http/ConverterInterface.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Http;
 

--- a/Gateway/Http/Transfer.php
+++ b/Gateway/Http/Transfer.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Http;
 

--- a/Gateway/Validator/Result.php
+++ b/Gateway/Validator/Result.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Validator;
 

--- a/Gateway/Validator/ValidatorComposite.php
+++ b/Gateway/Validator/ValidatorComposite.php
@@ -10,6 +10,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+declare(strict_types=1);
 
 namespace HawkSearch\Connector\Gateway\Validator;
 


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 2.11 for features/bugs / master for hot fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| BC breaks?    | no
| Tests pass?   | yes
| Tickets       | 

Fix the missing `declare(strict_types=1)` directive in the file. 
See [Strict typing (php. net)](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.strict) to learn more about why you may need use this directive.