### PR TITLE
fix: exception: each method must have a doc block

### DIFF
--- a/Api/Data/HawkSearchFieldInterface.php
+++ b/Api/Data/HawkSearchFieldInterface.php
@@ -63,6 +63,9 @@ interface HawkSearchFieldInterface
     const CREATE_DATE = 'CreateDate';
     const MODIFY_DATE = 'ModifyDate';
 
+    /**
+     * @return int
+     */
     public function getFieldId(): int;
 
     /**
@@ -70,6 +73,9 @@ interface HawkSearchFieldInterface
      */
     public function setFieldId(string $value);
 
+    /**
+     * @return string
+     */
     public function getSyncGuid(): string;
 
     /**
@@ -77,6 +83,9 @@ interface HawkSearchFieldInterface
      */
     public function setSyncGuid(string $value);
 
+    /**
+     * @return string
+     */
     public function getName(): string;
 
     /**
@@ -84,6 +93,9 @@ interface HawkSearchFieldInterface
      */
     public function setName(string $value);
 
+    /**
+     * @return string
+     */
     public function getFieldType(): string;
 
     /**
@@ -91,6 +103,9 @@ interface HawkSearchFieldInterface
      */
     public function setFieldType(string $value);
 
+    /**
+     * @return string
+     */
     public function getLabel(): string;
 
     /**
@@ -98,6 +113,9 @@ interface HawkSearchFieldInterface
      */
     public function setLabel(string $value);
 
+    /**
+     * @return string
+     */
     public function getType(): string;
 
     /**
@@ -105,6 +123,9 @@ interface HawkSearchFieldInterface
      */
     public function setType(string $value);
 
+    /**
+     * @return int
+     */
     public function getBoost(): int;
 
     /**
@@ -112,6 +133,9 @@ interface HawkSearchFieldInterface
      */
     public function setBoost(int $value);
 
+    /**
+     * @return int
+     */
     public function getFacetHandler(): int;
 
     /**
@@ -119,6 +143,9 @@ interface HawkSearchFieldInterface
      */
     public function setFacetHandler(int $value);
 
+    /**
+     * @return bool
+     */
     public function getIsPrimaryKey(): bool;
 
     /**
@@ -126,6 +153,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsPrimaryKey(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsOutput(): bool;
 
     /**
@@ -133,6 +163,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsOutput(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsShingle(): bool;
 
     /**
@@ -140,6 +173,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsShingle(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsBestFragment(): bool;
 
     /**
@@ -147,6 +183,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsBestFragment(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsDictionary(): bool;
 
     /**
@@ -154,6 +193,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsDictionary(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsSort(): bool;
 
     /**
@@ -161,6 +203,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsSort(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsPrefix(): bool;
 
     /**
@@ -168,6 +213,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsPrefix(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsHidden(): bool;
 
     /**
@@ -175,6 +223,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsHidden(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsCompare(): bool;
 
     /**
@@ -182,6 +233,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsCompare(bool $value);
 
+    /**
+     * @return int
+     */
     public function getSortOrder(): int;
 
     /**
@@ -189,6 +243,9 @@ interface HawkSearchFieldInterface
      */
     public function setSortOrder(int $value);
 
+    /**
+     * @return string
+     */
     public function getPartialQuery(): string;
 
     /**
@@ -196,6 +253,9 @@ interface HawkSearchFieldInterface
      */
     public function setPartialQuery(string $value);
 
+    /**
+     * @return bool
+     */
     public function getIsKeywordText(): bool;
 
     /**
@@ -203,6 +263,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsKeywordText(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsQuery(): bool;
 
     /**
@@ -210,6 +273,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsQuery(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getIsQueryText(): bool;
 
     /**
@@ -217,6 +283,9 @@ interface HawkSearchFieldInterface
      */
     public function setIsQueryText(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getSkipCustom(): bool;
 
     /**
@@ -224,6 +293,9 @@ interface HawkSearchFieldInterface
      */
     public function setSkipCustom(bool $value);
 
+    /**
+     * @return bool
+     */
     public function getStripHtml(): bool;
 
     /**
@@ -231,6 +303,9 @@ interface HawkSearchFieldInterface
      */
     public function setStripHtml(bool $value);
 
+    /**
+     * @return int
+     */
     public function getMinNGramAnalyzer(): int;
 
     /**
@@ -238,6 +313,9 @@ interface HawkSearchFieldInterface
      */
     public function setMinNGramAnalyzer(int $value);
 
+    /**
+     * @return int
+     */
     public function getMaxNGramAnalyzer(): int;
 
     /**
@@ -245,6 +323,9 @@ interface HawkSearchFieldInterface
      */
     public function setMaxNGramAnalyzer(int $value);
 
+    /**
+     * @return int
+     */
     public function getCoordinateType(): int;
 
     /**
@@ -252,6 +333,9 @@ interface HawkSearchFieldInterface
      */
     public function setCoordinateType(int $value);
 
+    /**
+     * @return bool
+     */
     public function getOmitNorms(): bool;
 
     /**
@@ -259,6 +343,9 @@ interface HawkSearchFieldInterface
      */
     public function setOmitNorms(bool $value);
 
+    /**
+     * @return string
+     */
     public function getItemMapping(): string;
 
     /**
@@ -266,6 +353,9 @@ interface HawkSearchFieldInterface
      */
     public function setItemMapping(string $value);
 
+    /**
+     * @return string
+     */
     public function getDefaultValue(): string;
 
     /**
@@ -273,6 +363,9 @@ interface HawkSearchFieldInterface
      */
     public function setDefaultValue(string $value);
 
+    /**
+     * @return bool
+     */
     public function getUseForPrediction(): bool;
 
     /**
@@ -280,6 +373,9 @@ interface HawkSearchFieldInterface
      */
     public function setUseForPrediction(bool $value);
 
+    /**
+     * @return string
+     */
     public function getCopyTo(): string;
 
     /**
@@ -287,6 +383,9 @@ interface HawkSearchFieldInterface
      */
     public function setCopyTo(string $value);
 
+    /**
+     * @return string
+     */
     public function getAnalyzer(): string;
 
     /**
@@ -294,6 +393,9 @@ interface HawkSearchFieldInterface
      */
     public function setAnalyzer(string $value);
 
+    /**
+     * @return bool
+     */
     public function getDoNotStore(): bool;
 
     /**
@@ -301,6 +403,9 @@ interface HawkSearchFieldInterface
      */
     public function setDoNotStore(bool $value);
 
+    /**
+     * @return string
+     */
     public function getTags(): string;
 
     /**
@@ -339,6 +444,9 @@ interface HawkSearchFieldInterface
      */
     public function setPreviewMapping(string $value);
 
+    /**
+     * @return bool
+     */
     public function getOmitTfAndPos(): bool;
 
     /**
@@ -346,6 +454,9 @@ interface HawkSearchFieldInterface
      */
     public function setOmitTfAndPos(bool $value);
 
+    /**
+     * @return string
+     */
     public function getCreateDate(): string;
 
     /**
@@ -353,6 +464,9 @@ interface HawkSearchFieldInterface
      */
     public function setCreateDate(string $value);
 
+    /**
+     * @return string
+     */
     public function getModifyDate(): string;
 
     /**


### PR DESCRIPTION
| Q             | A
|---------------| ---
| Branch?       | 2.11 
| Bug fix?      | yes
| New feature?  | no <!-- please update CHANGELOG-*.md file -->
| Deprecations? | no <!-- please update UPGRADE-*.md and CHANGELOG-*.md files -->
| BC breaks?    | no <!-- please update UPGRADE-*.md and CHANGELOG-*.md files -->
| Tests pass?   | yes
| Tickets       | 


Return back `@return` docblock in `Api\Data` interfaces. `\Magento\Framework\Reflection\TypeProcessor` doesn't allow to have `Api\Data` interfaces without phpDoc annotation. We will overcome it later in https://bridgeline.atlassian.net/browse/HC-1755

